### PR TITLE
Update URL in PKGBUILD and update CMake minimum required version to 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.0.2)
+cmake_minimum_required (VERSION 3.10)
 
 project(libxil C)
 

--- a/packaging/PKGBUILD
+++ b/packaging/PKGBUILD
@@ -1,17 +1,17 @@
-# $Id$
 # Maintainer: Daniel Krebs <github@daniel-krebs.net>
+# Contributor: Bekir Altindal <bekir.altindal@rwth-aachen.de>
+
 pkgname=libxil
-branch=master
-pkgver=0.1
-pkgrel=2
+pkgver=0.1.0
+pkgrel=3
 pkgdesc="Modified Xilinx drivers for VILLASnode: https://github.com/Xilinx/embeddedsw"
 arch=('x86_64')
-url="https://git.rwth-aachen.de/VILLASframework/libxil/"
-source=("$url/repository/$branch/archive.tar.bz2")
+url="https://github.com/VILLASframework/${pkgname}"
+source=("${pkgname}-${pkgver}.tar.gz::${url}/archive/refs/tags/v${pkgver}.tar.gz")
 sha256sums=(SKIP)
 
 build() {
-	cd "$(sh -c "echo ${pkgname}-*")"
+	cd ${pkgname}-${pkgver}
 
 	mkdir -p build
 	cd build
@@ -21,7 +21,7 @@ build() {
 }
 
 package() {
-	cd "$(sh -c "echo ${pkgname}-*")"/build
+	cd ${pkgname}-${pkgver}/build
 
 	make DESTDIR="$pkgdir" install
 }

--- a/packaging/PKGBUILD
+++ b/packaging/PKGBUILD
@@ -3,26 +3,29 @@
 
 pkgname=libxil
 pkgver=0.1.0
-pkgrel=3
+pkgrel=4
 pkgdesc="Modified Xilinx drivers for VILLASnode: https://github.com/Xilinx/embeddedsw"
 arch=('x86_64')
 url="https://github.com/VILLASframework/${pkgname}"
-source=("${pkgname}-${pkgver}.tar.gz::${url}/archive/refs/tags/v${pkgver}.tar.gz")
+license=(MIT)
+makedepends=(cmake
+             git)
+#source=("${pkgname}-${pkgver}.tar.gz::${url}/archive/refs/tags/v${pkgver}.tar.gz")
+source=("${pkgname}-${pkgver}::git+https://github.com/bekiralti/libxil#branch=tmp")
 sha256sums=(SKIP)
 
 build() {
-	cd ${pkgname}-${pkgver}
+  cd ${pkgname}-${pkgver}
 
-	mkdir -p build
-	cd build
+  mkdir -p build
+  cd build
 
-	cmake .. -DCMAKE_INSTALL_PREFIX=/usr
-	make
+  cmake .. -DCMAKE_INSTALL_PREFIX=/usr
+  make
 }
 
 package() {
-	cd ${pkgname}-${pkgver}/build
+  cd ${pkgname}-${pkgver}/build
 
-	make DESTDIR="$pkgdir" install
+  make DESTDIR="$pkgdir" install
 }
-

--- a/packaging/PKGBUILD
+++ b/packaging/PKGBUILD
@@ -8,10 +8,8 @@ pkgdesc="Modified Xilinx drivers for VILLASnode: https://github.com/Xilinx/embed
 arch=('x86_64')
 url="https://github.com/VILLASframework/${pkgname}"
 license=(MIT)
-makedepends=(cmake
-             git)
-#source=("${pkgname}-${pkgver}.tar.gz::${url}/archive/refs/tags/v${pkgver}.tar.gz")
-source=("${pkgname}-${pkgver}::git+https://github.com/bekiralti/libxil#branch=tmp")
+makedepends=(cmake)
+source=("${pkgname}-${pkgver}.tar.gz::${url}/archive/refs/tags/v${pkgver}.tar.gz")
 sha256sums=(SKIP)
 
 build() {


### PR DESCRIPTION
Hello,

there are alltogether 3 commits in this Pull Request.

1. Update PKGBUILD.
2. Update CMake minimum required version to 3.10.
3. cmake was missing in the makedepends. Also set the correct value for the license variable.

### 1. Update PKGBUILD

I was actually trying to install villas node on Arch Linux with the provided PKGBUILD and stumbled over the `libxil` dependency. Thankfully I found it inside the `.gitmodules` file. However it looks like the PKGBUILD for `libxil` is outdated, because whenever I tried to download `libxil` from the provided url

https://github.com/VILLASframework/libxil

I encountered the Error 404 GitLab site. Hence, I updated the url to the GitHub release now. 

### 2. Update CMake minimum required version to 3.10.

There is just one issue though. If you try to run the PKGBUILD with `makepkg -si` you will encounter a `CMake minimum required version` error. 

```bash
CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```

I tested it on my fork (branch tmp) with CMake version 3.10 and it installed without problems. That is why I also made this second commit updating the CMake minimum required version to 3.10.

### Future Step
Once a new release of `libxil` is published another update to the PKGBUILD file might be necessary if e.g. the release version updates to 0.1.1 from 0.1.0.

Cheers
Bekir :)